### PR TITLE
Fix: Documentation deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -24,7 +24,6 @@ jobs:
             auto-update-conda: true
             environment-file: dev/environment.yml
             activate-environment: asf_docenv
-            miniforge-variant: Mambaforge
             use-mamba: true
             miniforge-version: latest
             python-version: 3.11


### PR DESCRIPTION
The documentation pipeline fails during the `setup-miniconda` action. This branch provides a simple fix by removing a deprecated option.